### PR TITLE
feat: register sonrası otomatik login ve local kurulum rehberi

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,85 @@ Etkinlik oluşturmak, bağlantı paylaşmak ve içerik toplamak sadece birkaç d
 - **Dosya Depolama**: Sunucu klasör sistemi
 - **QR Kod**: qrcode.js kütüphanesi
 
+## 🛠️ Local Kurulum
+
+### Gereksinimler
+- PHP 8.0 veya üzeri
+- MySQL 5.7 veya üzeri
+- Composer
+
+### Kurulum Adımları
+
+1. **Projeyi klonlayın**
+   ```bash
+   git clone [repository-url]
+   cd wedding-box
+   ```
+
+2. **Composer bağımlılıklarını yükleyin**
+   ```bash
+   composer install
+   ```
+
+3. **Environment dosyasını oluşturun**
+   ```bash
+   cp env.example .env
+   ```
+
+4. **Veritabanı ayarlarını yapılandırın**
+   
+   `.env` dosyasını düzenleyerek veritabanı bilgilerinizi girin:
+   ```env
+   DB_HOST=localhost
+   DB_NAME=wedding_box
+   DB_USER=root
+   DB_PASS=your_password
+   DB_PORT=3306
+   ```
+
+5. **Veritabanını oluşturun**
+   ```bash
+   mysql -u root -p
+   CREATE DATABASE wedding_box;
+   exit;
+   ```
+
+6. **Veritabanı şemasını yükleyin**
+   ```bash
+   mysql -u root -p wedding_box < database/schema.sql
+   ```
+
+7. **Uygulamayı başlatın**
+   ```bash
+   php -S localhost:8001 -t public
+   ```
+
+8. **Tarayıcınızda açın**
+   ```
+   http://localhost:8001
+   ```
+
+### Google OAuth Kurulumu (Opsiyonel)
+
+Google Drive entegrasyonu için:
+
+1. [Google Cloud Console](https://console.cloud.google.com/)'da yeni bir proje oluşturun
+2. Google Drive API'yi etkinleştirin
+3. OAuth 2.0 kimlik bilgilerini oluşturun
+4. `.env` dosyasına Google bilgilerinizi ekleyin:
+   ```env
+   GOOGLE_CLIENT_ID=your_client_id
+   GOOGLE_CLIENT_SECRET=your_client_secret
+   GOOGLE_REDIRECT_URI=http://localhost:8001/auth/google/callback
+   ```
+
+### Dosya İzinleri
+
+`uploads/` klasörünün yazılabilir olduğundan emin olun:
+```bash
+chmod 755 uploads/
+```
+
 ## 📋 Proje İlerleme
 
 Proje ilerleme durumu için [PROJECT_PROGRESS.md](./PROJECT_PROGRESS.md) dosyasını inceleyebilirsiniz.

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -145,10 +145,24 @@ class AuthController
             // Veritabanında kullanıcı oluştur
             $userId = $this->db->createUser($email, $passwordHash, $displayName);
             
+            // Session ayarlarını yapılandır (daha uzun süre açık kalması için)
+            ini_set('session.gc_maxlifetime', 86400); // 24 saat
+            ini_set('session.cookie_lifetime', 86400); // 24 saat
+            ini_set('session.cookie_secure', 0); // HTTP için
+            ini_set('session.cookie_httponly', 1); // XSS koruması
+            ini_set('session.use_strict_mode', 1); // Güvenlik
+            
+            // Session'a kullanıcı bilgilerini kaydet (otomatik login)
+            session_start();
+            $_SESSION['user_id'] = $userId;
+            $_SESSION['email'] = $email;
+            $_SESSION['display_name'] = $displayName;
+            $_SESSION['login_time'] = time(); // Giriş zamanını kaydet
+            
             $response->getBody()->write(json_encode([
                 'success' => true,
-                'message' => 'Kayıt başarılı! Giriş yapabilirsiniz.',
-                'redirect' => '/auth/login'
+                'message' => 'Kayıt başarılı! Hoş geldiniz.',
+                'redirect' => '/dashboard'
             ]));
             return $response->withHeader('Content-Type', 'application/json');
             


### PR DESCRIPTION
- AuthController'da register metodunu güncelle: kullanıcı kayıt olduktan sonra otomatik olarak login olur
- Session ayarlarını register metoduna ekle
- Yönlendirmeyi /auth/login'den /dashboard'a değiştir
- README.md'ye kapsamlı local kurulum rehberi ekle:
  * Gereksinimler ve kurulum adımları
  * Veritabanı konfigürasyonu
  * php -S localhost:8001 -t public komutu
  * Google OAuth kurulumu (opsiyonel)
  * Dosya izinleri ayarları

Bu değişiklikler kullanıcı deneyimini iyileştirir ve geliştiricilerin projeyi kolayca local ortamında çalıştırmasını sağlar.